### PR TITLE
Add Electron windowOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,9 @@ export new ElectronAuth0Login({
     auth0Audience: 'https://api.mydomain.com',
     auth0ClientId: 'abc123ghiMyApp',
     auth0Domain: 'my-domain.eu.auth0.com',
-    auth0Scopes: 'given_name profile offline_access' // add 'offline_access'
-
-    // extra properties
-    applicationName: 'my-cool-app',
-    useRefreshTokens: true
+    auth0Scopes: 'given_name profile offline_access', // add 'offline_access'
+    applicationName: 'my-cool-app', // add an application name
+    useRefreshTokens: true // add useRefreshTokens: true
 });
 ```
 
@@ -118,6 +116,35 @@ async function doSomethingWithAPI() {
         }
     });
 }
+```
+
+## Configuring the login window
+
+You can also pass options to the electron `BrowserWindow` by adding a `windowOptions` object to your config, e.g.
+
+```typescript
+const auth = new ElectronAuth0Login({
+    auth0Audience: 'https://api.mydomain.com',
+    auth0ClientId: 'abc123ghiMyApp',
+    auth0Domain: 'my-domain.eu.auth0.com',
+    auth0Scopes: 'given_name profile',
+    windowOptions: {
+        width: 1024,
+        height: 640,
+    }
+});
+```
+
+These options will be merged into the default options, which are
+
+```
+{
+    width: 800,
+    height: 600,
+    alwaysOnTop: true,
+    title: 'Log in',
+    backgroundColor: '#202020'
+};
 ```
 
 ## Credits

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-auth0-login",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Provides Auth0 authentication services for your Electron.js applicatioin",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import codependency from 'codependency';
-import {BrowserWindow} from 'electron';
+import { BrowserWindow } from 'electron';
 import qs from 'qs';
 import request from 'request-promise-native';
 import url from 'url';
@@ -13,11 +13,25 @@ export default class ElectronAuth0Login {
     private config: Config;
     private tokenProperties: TokenProperties | null;
     private useRefreshToken: boolean;
+    private windowConfig = {
+        width: 800,
+        height: 600,
+        alwaysOnTop: true,
+        title: 'Log in',
+        backgroundColor: '#202020'
+    };
 
     constructor(config: Config) {
         this.config = config;
         this.tokenProperties = null;
         this.useRefreshToken = !!(config.useRefreshTokens && config.applicationName && keytar);
+
+        if (config.windowConfig) {
+            this.windowConfig = {
+                ...this.windowConfig,
+                ...config.windowConfig
+            }
+        }
 
         if (config.useRefreshTokens && !config.applicationName) {
             console.warn('electron-auth0-login: cannot use refresh tokens without an application name');
@@ -101,13 +115,7 @@ export default class ElectronAuth0Login {
                 redirect_uri: `https://${this.config.auth0Domain}/mobile`
             });
 
-            const authWindow = new BrowserWindow({
-                width: 800,
-                height: 600,
-                alwaysOnTop: true,
-                title: 'Log in',
-                backgroundColor: '#202020'
-            });
+            const authWindow = new BrowserWindow(this.windowConfig);
     
             authWindow.webContents.on('did-navigate' as any, (event: any, href: string) => {
                 const location = url.parse(href);

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -10,7 +10,9 @@ interface Config {
     // What permissions do we want?
     auth0Scopes: string,
 
-    useRefreshTokens?: boolean
+    useRefreshTokens?: boolean,
+
+    windowConfig?: object
 }
 
 interface PKCEPair {


### PR DESCRIPTION
You can now pass options to the electron `BrowserWindow` by adding a `windowOptions` object to your config, e.g.

```typescript
const auth = new ElectronAuth0Login({
    auth0Audience: 'https://api.mydomain.com',
    auth0ClientId: 'abc123ghiMyApp',
    auth0Domain: 'my-domain.eu.auth0.com',
    auth0Scopes: 'given_name profile',
    windowOptions: {
        width: 1024,
        height: 640,
    }
});
```

These options will be merged into the default options, which are

```
{
    width: 800,
    height: 600,
    alwaysOnTop: true,
    title: 'Log in',
    backgroundColor: '#202020'
};
```