### PR TITLE
Added option to send custom auth0 parameters for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,11 @@ export new ElectronAuth0Login({
     auth0Domain: 'my-domain.eu.auth0.com',
     auth0Scopes: 'given_name profile offline_access', // add 'offline_access'
     applicationName: 'my-cool-app', // add an application name
-    useRefreshTokens: true // add useRefreshTokens: true
+    useRefreshTokens: true, // add useRefreshTokens: true
+    auth0Params: {
+        //your custom auth0 parameters
+        connection_scope: 'offline_access' // etc..
+    }
 });
 ```
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -6,6 +6,7 @@ export interface Config {
     auth0Scopes: string;
     useRefreshTokens?: boolean;
     windowConfig?: object;
+    auth0Params?: object;
 }
 export default class ElectronAuth0Login {
     private config;

--- a/dist/index.js
+++ b/dist/index.js
@@ -38,7 +38,7 @@ class ElectronAuth0Login {
             console.warn('electron-auth0-login: cannot use refresh tokens without an application name');
         }
         if (config.useRefreshTokens && !keytar) {
-            console.warn('electron-auth0-login: cannot use refresh tokens without node-keytar installed');
+            console.warn('electron-auth0-login: cannot use refresh tokens without keytar installed');
         }
     }
     logout() {
@@ -105,15 +105,7 @@ class ElectronAuth0Login {
     getAuthCode(pkcePair) {
         return __awaiter(this, void 0, void 0, function* () {
             return new Promise((resolve, reject) => {
-                const authCodeUrl = `https://${this.config.auth0Domain}/authorize?` + qs_1.default.stringify({
-                    audience: this.config.auth0Audience,
-                    scope: this.config.auth0Scopes,
-                    response_type: 'code',
-                    client_id: this.config.auth0ClientId,
-                    code_challenge: pkcePair.challenge,
-                    code_challenge_method: 'S256',
-                    redirect_uri: `https://${this.config.auth0Domain}/mobile`
-                });
+                const authCodeUrl = `https://${this.config.auth0Domain}/authorize?` + qs_1.default.stringify(Object.assign({ audience: this.config.auth0Audience, scope: this.config.auth0Scopes, response_type: 'code', client_id: this.config.auth0ClientId, code_challenge: pkcePair.challenge, code_challenge_method: 'S256', redirect_uri: `https://${this.config.auth0Domain}/mobile` }, this.config.auth0Params));
                 const authWindow = new electron_1.BrowserWindow(this.windowConfig);
                 authWindow.webContents.on('did-navigate', (event, href) => {
                     const location = url_1.default.parse(href);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-auth0-login",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-auth0-login",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Provides Auth0 authentication services for your Electron.js application",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@ export interface Config {
     auth0Domain: string,
     auth0Scopes: string, // What permissions do we want?
     useRefreshTokens?: boolean,
-    windowConfig?: object
+    windowConfig?: object,
+    auth0Params?: object
 }
 
 interface Auth0TokenResponse {
@@ -134,7 +135,8 @@ export default class ElectronAuth0Login {
                 client_id: this.config.auth0ClientId,
                 code_challenge: pkcePair.challenge,
                 code_challenge_method: 'S256',
-                redirect_uri: `https://${this.config.auth0Domain}/mobile`
+                redirect_uri: `https://${this.config.auth0Domain}/mobile`,
+                ...this.config.auth0Params
             });
 
             const authWindow = new BrowserWindow(this.windowConfig);


### PR DESCRIPTION
There are scenarios where we have to send custom params to the auth0 authorization page, an example includes the "connection_scope", so this PR created to make use of such params.
@jbreckmckye 