### PR TITLE
made isLoggedIn function asynchronous

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-auth0-login",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Provides Auth0 authentication services for your Electron.js application",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/library/operations.ts
+++ b/src/library/operations.ts
@@ -4,7 +4,7 @@ import { Context } from '../types';
  * Return a usable auth token or, failing that, try to get a new one
  * You should use this whenever you want to auth e.g. an API request
  */
-export async function getToken (ctx: Context): Promise<string> {
+export async function getToken(ctx: Context): Promise<string> {
     const {
         authAPI,
         logger: {
@@ -48,15 +48,15 @@ export async function getToken (ctx: Context): Promise<string> {
 /**
  * Check whether we are logged in
  */
-export function isLoggedIn (ctx: Context) {
-    return !!ctx.tokens.get();
+export async function isLoggedIn(ctx: Context) {
+    return !!await ctx.tokens.get();
 }
 
 /**
  * Manually start a login flow.
  * If you just want a token, use getToken(), which will log in only if we don't have a token available.
  */
-export async function login (ctx: Context): Promise<string> {
+export async function login(ctx: Context): Promise<string> {
     const {
         authAPI,
         authWindow,
@@ -94,7 +94,7 @@ export async function login (ctx: Context): Promise<string> {
 /**
  * Log the user out
  */
-export async function logout (ctx: Context) {
+export async function logout(ctx: Context) {
     const {
         authWindow,
         refreshTokens,

--- a/src/library/operations.ts
+++ b/src/library/operations.ts
@@ -4,7 +4,7 @@ import { Context } from '../types';
  * Return a usable auth token or, failing that, try to get a new one
  * You should use this whenever you want to auth e.g. an API request
  */
-export async function getToken(ctx: Context): Promise<string> {
+export async function getToken (ctx: Context): Promise<string> {
     const {
         authAPI,
         logger: {
@@ -48,7 +48,7 @@ export async function getToken(ctx: Context): Promise<string> {
 /**
  * Check whether we are logged in
  */
-export async function isLoggedIn(ctx: Context) {
+export async function isLoggedIn (ctx: Context) {
     return !!await ctx.tokens.get();
 }
 
@@ -56,7 +56,7 @@ export async function isLoggedIn(ctx: Context) {
  * Manually start a login flow.
  * If you just want a token, use getToken(), which will log in only if we don't have a token available.
  */
-export async function login(ctx: Context): Promise<string> {
+export async function login (ctx: Context): Promise<string> {
     const {
         authAPI,
         authWindow,
@@ -94,7 +94,7 @@ export async function login(ctx: Context): Promise<string> {
 /**
  * Log the user out
  */
-export async function logout(ctx: Context) {
+export async function logout (ctx: Context) {
     const {
         authWindow,
         refreshTokens,


### PR DESCRIPTION
When checking for authentication, isLoggedIn always returns true due to the promise being returned in the ctx.tokens.get() call.

This was causing logic errors when checking for prior authentication in electron applications.