### PR TITLE
Fix issue #37

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,6 +37,8 @@ export type Config = {
         domain: string,
         // This will be custom to your application, e.g. 'given_name profile'
         scopes: string
+        // Optional Field; This will be the database connection you specify (prefered to use when have multiple connections), it uses the default connection when value isn't provided
+        connection?: string
     },
 
     // Customise the login

--- a/src/adapters/authWindow.ts
+++ b/src/adapters/authWindow.ts
@@ -38,6 +38,7 @@ export const authWindow: Adapter = (config) => {
                 code_challenge: pair.challenge,
                 code_challenge_method: 'S256',
                 redirect_uri: `https://${config.auth0.domain}/mobile`,
+                connection: config.auth0?.connection,
                 // Custom parameters
                 ...config.login?.authorizeParams
             });

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,8 @@ export type Config = {
         clientId: string,
         domain: string,
         // This will be custom to your application, e.g. 'given_name profile'
-        scopes: string
+        scopes: string,
+        connection?: string
     },
 
     // Customise the login


### PR DESCRIPTION
Add `connection` to auth0 config object as a not required field to use the default db connection when value is not provided

It tested against several connection with default and non default db connections